### PR TITLE
Using strings for keys

### DIFF
--- a/server/Sprig.Models/Message.cs
+++ b/server/Sprig.Models/Message.cs
@@ -9,6 +9,6 @@ public abstract class Message
 {
     public const int CurrentProtocolVersion = 1;
 
-    [Key(0)]
+    [Key("ProtocolVersion")]
     public int ProtocolVersion { get; set; } = CurrentProtocolVersion;
 }

--- a/server/Sprig.Models/Response.cs
+++ b/server/Sprig.Models/Response.cs
@@ -23,6 +23,6 @@ public class Response : Message
         InvalidRequest,
     }
 
-    [Key(1)]
+    [Key("ResponseCode")]
     public Code ResponseCode { get; set; }
 }


### PR DESCRIPTION
Using strings as the key values in MessagePack to make interop with javascript easier. The format (in JSON) looks like this

`BeginSessionRequest` looks like `[0,{"ProtocolVersion":1}]`
`Response` looks like `[1,{"ProtocolVersion":1,"ResponseCode":1}]`
