### PR TITLE
config

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,6 +6,6 @@ module.exports = {
         ],
     },
     resolve: {
-        extensions: ['.ts'],
+        extensions: ['.ts', '...'],
     },
 };


### PR DESCRIPTION
https://webpack.js.org/configuration/resolve/#resolveextensions

> Note that using resolve.extensions like above will override the default array, meaning that webpack will no longer try to resolve modules using the default extensions. However you can use '...' to access the default extensions: